### PR TITLE
find_packages with errors

### DIFF
--- a/src/ros_introspect/package.py
+++ b/src/ros_introspect/package.py
@@ -271,4 +271,8 @@ class Package:
 
 def find_packages(root_folder=pathlib.Path('.')):
     for package_root in find_package_roots(root_folder):
-        yield Package(package_root)
+        try:
+            yield Package(package_root)
+        except Exception as e:
+            print(f'{Fore.YELLOW}Unable to parse package at {package_root} because {e}. Skipping...{Fore.RESET}',
+                  file=sys.stderr)

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -13,6 +13,11 @@ def test_find_packages():
         print(pkg)
 
 
+def test_invalid_package_crawl():
+    pkgs = list(find_packages(TEST_DATA_FOLDER / 'fake_git_root'))
+    assert len(pkgs) == 0
+
+
 def test_waymond():
     pkg = Package(TEST_DATA_FOLDER / 'waymond')
     manifest = pkg.package_xml


### PR DESCRIPTION
Changes so that `find_packages` will find all **valid** packages, and not error out when it encounters something invalid. 